### PR TITLE
Omit buffer size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,6 @@
 
 import { Realm } from './realm';
 
-const BUFFER_SIZE = 256;
-
 if (typeof AudioWorkletNode !== 'function') {
   window.AudioWorkletNode = function AudioWorkletNode (context, name) {
     const processor = getProcessorsForContext(context)[name];
@@ -36,7 +34,7 @@ if (typeof AudioWorkletNode !== 'function') {
     const inst = new processor.Processor({});
 
     this.port = processor.port;
-    const scriptProcessor = context.createScriptProcessor(BUFFER_SIZE);
+    const scriptProcessor = context.createScriptProcessor();
     scriptProcessor.node = this;
     scriptProcessor.processor = processor;
     scriptProcessor.instance = inst;


### PR DESCRIPTION
The following is quote from
https://webaudio.github.io/web-audio-api/#scriptprocessornode

` This value will be picked by the implementation if the bufferSize
argument to createScriptProcessor() is not passed in, or is set to 0`

I think that the browsers select optimized buffer size. Therefore, this PR omitted buffer size. Actually, when I tried to use Microsoft Edge, that was better.