### PR TITLE
Do not crash if non-prefixed AudioContext isn't available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ if (typeof AudioWorkletNode !== 'function') {
     return scriptProcessor;
   };
 
-  Object.defineProperty(AudioContext.prototype, 'audioWorklet', {
+  Object.defineProperty((window.AudioContext||webkitAudioContext).prototype, 'audioWorklet', {
     get () {
       return this.$$audioWorklet || (this.$$audioWorklet = new window.AudioWorklet(this));
     }


### PR DESCRIPTION
Safari 11.x only has prefixed `webAudioContext`: without this patch the polyfill crashes.

Fixes #9 