### PR TITLE
IMPROVED: pass audioWorklet channel count to scriptProcessor constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,9 @@ let nextPort;
 if (typeof AudioWorkletNode !== 'function') {
   self.AudioWorkletNode = function AudioWorkletNode (context, name, options) {
     const processor = getProcessorsForContext(context)[name];
-    const scriptProcessor = context.createScriptProcessor();
+    const outputChannels = options && options.outputChannelCount ? options.outputChannelCount[0] : 2;
+    const inputChannels = options && options.inputChannelCount ? options.inputChannelCount[0] : 2;     
+    const scriptProcessor = context.createScriptProcessor(undefined, inputChannels, outputChannels);
 
     scriptProcessor.parameters = new Map();
     if (processor.properties) {

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,7 @@ if (typeof AudioWorkletNode !== 'function') {
   self.AudioWorkletNode = function AudioWorkletNode (context, name, options) {
     const processor = getProcessorsForContext(context)[name];
     const outputChannels = options && options.outputChannelCount ? options.outputChannelCount[0] : 2;
-    const inputChannels = options && options.inputChannelCount ? options.inputChannelCount[0] : 2;     
-    const scriptProcessor = context.createScriptProcessor(undefined, inputChannels, outputChannels);
+    const scriptProcessor = context.createScriptProcessor(undefined, 2, outputChannels);
 
     scriptProcessor.parameters = new Map();
     if (processor.properties) {


### PR DESCRIPTION
App using audioWorklet could crash if used input/outputChannelCount value was different than the default channel count of ScriptProcessor (which is 2).

This should fix it.