### PR TITLE
Set sampleRate and currentTime on initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,8 @@ if (typeof AudioWorkletNode !== 'function') {
         return r.text();
       }).then(code => {
         const context = {
-          sampleRate: 0,
-          currentTime: 0,
+          sampleRate: this.$$context.sampleRate,
+          currentTime: this.$$context.currentTime,
           AudioWorkletProcessor () {
             this.port = nextPort;
           },
@@ -80,6 +80,7 @@ if (typeof AudioWorkletNode !== 'function') {
             };
           }
         };
+
         context.self = context;
         const realm = new Realm(context, document.documentElement);
         realm.exec(((options && options.transpile) || String)(code));

--- a/src/realm.js
+++ b/src/realm.js
@@ -39,5 +39,5 @@ export function Realm (scope, parentElement) {
         ${vars};return function() {return eval(arguments[0])}}`
   ));
   doc.body.appendChild(script);
-  this.exec = win.$hook(scope, console);
+  this.exec = win.$hook.call(scope, scope, console);
 }


### PR DESCRIPTION
Fixes #14

I tried the solution proposed in #14, but the problem was that something was always trying to set `sampleRate` and `currentTime` in Firefox 71.

Hence, I opted to simply set the values in `context` directly.