### PR TITLE
Connect output-less script processor to destination to allow processing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,14 @@ if (typeof AudioWorkletNode !== 'function' || !("audioWorklet" in AudioContext.p
     scriptProcessor.processor = processor;
     scriptProcessor.instance = inst;
     scriptProcessor.onaudioprocess = onAudioProcess;
+
+    if (options.numberOfOutputs === 0) {
+      // On browsers that do support AudioWorklet, process() will be invoked for disconnected
+      // AudioWorkletNodes as long as they are created with numberOfOutputs: 0.
+      // In Safari, onaudioprocess is only invoked on a ScriptProcessorNode if it is connected to an output.
+      scriptProcessor.connect(context.destination);
+    }
+
     return scriptProcessor;
   };
 


### PR DESCRIPTION
As described in the code comment:
- On browsers that do support AudioWorklet, process() will be invoked for disconnected AudioWorkletNodes as long as they are created with `numberOfOutputs: 0` in the options
- In Safari, `onaudioprocess` is only invoked on a ScriptProcessorNode if it is connected to an output

The use case for input-only processors is performing audio analysis (rather than audio manipulation), e.g. for visualisation.

Tested in iOS Safari 12. Note that for the polyfill to work for me at all on this platform, I also needed PR #25 .

Some things that didn't work:
- Explicitly creating the ScriptProcessorNode with 0 `outputChannels` (as the third constructor argument): `process` still wasn't invoked unless the ScriptProcessorNode was connected to the output
- Connect the ScriptProcessorNode to the destination via a GainNode with gain 0 (seemed like a slightly safer option than connecting directly to the destination): *did* cause `process()` to be invoked, but the input was always silent (possibly an optimisation because the AudioContext can see the output is muted?)

Connecting *without* going through a zero-gain node would only cause surprising behaviour if someone created a polyfill AudioWorkletNode with `numberOfOutputs: 0` and then tried to output something from the node, which would suggest a programming error in any case.