### PR TITLE
Clear output buffers before calling 'process'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,11 @@ function onAudioProcess (e) {
   );
   const inputs = channelToArray(e.inputBuffer);
   const outputs = channelToArray(e.outputBuffer);
+  for (let i = 0; i < outputs.length; i++) {
+    for (let j = 0; j < outputs[i].length; j++) {
+      outputs[i][j] = 0;
+    }
+  }
   this.instance.process([inputs], [outputs], parameters);
 
   // @todo - keepalive


### PR DESCRIPTION
The output audio buffer must be zero-filled according to <https://webaudio.github.io/web-audio-api/#dom-audioworkletprocessor-process>. This patch ensures the output buffers cleared with zeros, I hope.